### PR TITLE
[Fix] Zero-indexed month value for events created from the terminal, to fix an incorrect month bug.

### DIFF
--- a/src/main/java/com/planner/scripter/ScriptFSM.java
+++ b/src/main/java/com/planner/scripter/ScriptFSM.java
@@ -1009,7 +1009,7 @@ public class ScriptFSM {
         // If dateString is null, then this event is recurring. So, use random numbers
         // we don't care about for the day, month and year.
         int day = dateString == null ? 1 : Integer.parseInt(dateString.split("-")[0].trim());
-        int month = dateString == null ? 1 : Integer.parseInt(dateString.split("-")[1].trim());
+        int month = dateString == null ? 1 : Integer.parseInt(dateString.split("-")[1].trim()) - 1; // Calendar.MONTH is zero-indexed
         int year = dateString == null ? 1 : Integer.parseInt(dateString.split("-")[2].trim());
 
         calendar.set(


### PR DESCRIPTION
Events created from the terminal showed a month value that was larger than the actual date, by a difference of 1. This is due to the Calendar class interpreting 'MONTH' values as zero-indexed. Fixed this by subtracting a 1 from month values of events created from the terminal.